### PR TITLE
fix: use attachment URLs for media in sitemap

### DIFF
--- a/src/main/resources/guillotine/resolvers/urlset.ts
+++ b/src/main/resources/guillotine/resolvers/urlset.ts
@@ -29,6 +29,7 @@ import {
 	DEFAULT_UPDATE_PERIOD,
 } from '/lib/app-sitemapxml/constants';
 import {queryForSitemapContent} from '/lib/app-sitemapxml/queryForSitemapContent';
+import {resolveSitemapGuillotinePath} from '/lib/app-sitemapxml/resolveSitemapUrl';
 import {URLSET_FIELD_NAME} from '/guillotine/constants';
 // import {safeMs} from '/guillotine/safeMs';
 
@@ -110,7 +111,7 @@ export const urlset = (graphQL: GraphQL): Resolver<
 		for (let i = 0; i < result.hits.length; i++) {
 			if (result.hits[i].type) {
 				TRACE && log.debug('%s resolver result.hits[%s].type: %s', URLSET_FIELD_NAME, i, result.hits[i].type);
-				const path = result.hits[i]._path.replace(site._path, '') || '/';
+				const path = resolveSitemapGuillotinePath(result.hits[i], site._path);
 				items.push({
 					changefreq: changefreq[result.hits[i].type] === DEFAULT_UPDATE_PERIOD ? undefined : changefreq[result.hits[i].type],
 					lastmod: result.hits[i].modifiedTime,

--- a/src/main/resources/lib/app-sitemapxml/queryForSitemapContent.ts
+++ b/src/main/resources/lib/app-sitemapxml/queryForSitemapContent.ts
@@ -21,6 +21,7 @@ import {
 	ES_MAX_ITEMS_LIMIT,
 	MAX_ITEMS_LIMIT
 } from '/lib/app-sitemapxml/constants';
+import type {SitemapContentHit} from '/lib/app-sitemapxml/resolveSitemapUrl';
 
 
 const GLOBALS: {
@@ -28,6 +29,20 @@ const GLOBALS: {
 } = {
 	alwaysAdd: 'portal:site',
 };
+
+
+function getPrimaryAttachmentName(
+	attachments: Record<string, unknown> | undefined
+): string | undefined {
+	if (!attachments) {
+		return undefined;
+	}
+	const keys = Object.keys(attachments);
+	if (!keys.length) {
+		return undefined;
+	}
+	return keys[0];
+}
 
 
 export function queryForSitemapContent({
@@ -168,11 +183,7 @@ export function queryForSitemapContent({
 	const stopBefore = Math.min(nodeQueryRes.hits.length, countBetweenZeroAndMaxItemsLimit);
 	DEBUG && log.debug('stopBefore: %s', stopBefore);
 
-	const contents: {
-		_path: string
-		modifiedTime?: string
-		type: string
-	}[] = [];
+	const contents: SitemapContentHit[] = [];
 
 	for (let i = 0; i < stopBefore; i++) {
 		const {id} = nodeQueryRes.hits[i];
@@ -180,18 +191,25 @@ export function queryForSitemapContent({
 			_path: string
 			modifiedTime?: string
 			type: string
+			attachments?: Record<string, unknown>
 		}>(id);
 		if (node) {
 			const {
 				_path,
 				modifiedTime,
 				type,
+				attachments,
 			} = node;
-			contents.push({
+			const attachmentName = getPrimaryAttachmentName(attachments);
+			const hit: SitemapContentHit = {
 				_path: _path.replace(/^\/content/, ''),
 				modifiedTime,
 				type,
-			});
+			};
+			if (attachmentName) {
+				hit.attachmentName = attachmentName;
+			}
+			contents.push(hit);
 		}
 	} // for
 	if (contents.length) {

--- a/src/main/resources/lib/app-sitemapxml/resolveSitemapUrl.ts
+++ b/src/main/resources/lib/app-sitemapxml/resolveSitemapUrl.ts
@@ -18,6 +18,11 @@ export function isMediaContentType(contentType: string): boolean {
 }
 
 
+function removeSitemapPathFromAttachmentUrl(url: string): string {
+	return url.replace('/sitemap.xml/_/attachment/', '/_/attachment/');
+}
+
+
 function buildAttachmentUrlParams(
 	hit: SitemapContentHit,
 	urlType: 'absolute' | 'server'
@@ -51,14 +56,14 @@ export function resolveSitemapLoc(
 	const useAttachment = isMediaContentType(hit.type);
 	if (overrideDomain) {
 		return useAttachment
-			? overrideDomain + attachmentUrl(buildAttachmentUrlParams(hit, 'server'))
+			? overrideDomain + removeSitemapPathFromAttachmentUrl(attachmentUrl(buildAttachmentUrlParams(hit, 'server')))
 			: overrideDomain + pageUrl({
 				path: hit._path,
 				type: 'server',
 			});
 	}
 	return useAttachment
-		? attachmentUrl(buildAttachmentUrlParams(hit, 'absolute'))
+		? removeSitemapPathFromAttachmentUrl(attachmentUrl(buildAttachmentUrlParams(hit, 'absolute')))
 		: pageUrl({
 			path: hit._path,
 			type: 'absolute',
@@ -75,7 +80,7 @@ export function resolveSitemapGuillotinePath(
 ): string {
 	const useAttachment = isMediaContentType(hit.type);
 	const serverUrl = useAttachment
-		? attachmentUrl(buildAttachmentUrlParams(hit, 'server'))
+		? removeSitemapPathFromAttachmentUrl(attachmentUrl(buildAttachmentUrlParams(hit, 'server')))
 		: pageUrl({
 			path: hit._path,
 			type: 'server',

--- a/src/main/resources/lib/app-sitemapxml/resolveSitemapUrl.ts
+++ b/src/main/resources/lib/app-sitemapxml/resolveSitemapUrl.ts
@@ -1,0 +1,92 @@
+import {attachmentUrl, pageUrl} from '/lib/xp/portal';
+
+
+/**
+ * One row from {@link queryForSitemapContent} used when building sitemap URLs.
+ */
+export interface SitemapContentHit {
+	_path: string
+	type: string
+	modifiedTime?: string
+	/** First attachment name when the underlying node has attachments (e.g. media). */
+	attachmentName?: string
+}
+
+
+export function isMediaContentType(contentType: string): boolean {
+	return contentType.indexOf('media:') === 0;
+}
+
+
+function buildAttachmentUrlParams(
+	hit: SitemapContentHit,
+	urlType: 'absolute' | 'server'
+): {
+	path: string
+	type: 'absolute' | 'server'
+	name?: string
+} {
+	const params: {
+		path: string
+		type: 'absolute' | 'server'
+		name?: string
+	} = {
+		path: hit._path,
+		type: urlType,
+	};
+	if (hit.attachmentName) {
+		params.name = hit.attachmentName;
+	}
+	return params;
+}
+
+
+/**
+ * Full public URL for `sitemap.xml` / JSON (`<loc>`), matching legacy `overrideDomain` behaviour.
+ */
+export function resolveSitemapLoc(
+	hit: SitemapContentHit,
+	overrideDomain: string
+): string {
+	const useAttachment = isMediaContentType(hit.type);
+	if (overrideDomain) {
+		return useAttachment
+			? overrideDomain + attachmentUrl(buildAttachmentUrlParams(hit, 'server'))
+			: overrideDomain + pageUrl({
+				path: hit._path,
+				type: 'server',
+			});
+	}
+	return useAttachment
+		? attachmentUrl(buildAttachmentUrlParams(hit, 'absolute'))
+		: pageUrl({
+			path: hit._path,
+			type: 'absolute',
+		});
+}
+
+
+/**
+ * Site-relative path for Guillotine `urlset`, aligned with historical `path.replace(site._path, '') || '/'`.
+ */
+export function resolveSitemapGuillotinePath(
+	hit: SitemapContentHit,
+	sitePath: string
+): string {
+	const useAttachment = isMediaContentType(hit.type);
+	const serverUrl = useAttachment
+		? attachmentUrl(buildAttachmentUrlParams(hit, 'server'))
+		: pageUrl({
+			path: hit._path,
+			type: 'server',
+		});
+
+	if (serverUrl.indexOf(sitePath) === 0) {
+		const rest = serverUrl.substring(sitePath.length);
+		if (!rest) {
+			return '/';
+		}
+		return rest.charAt(0) === '/' ? rest : `/${rest}`;
+	}
+	return serverUrl.charAt(0) === '/' ? serverUrl : `/${serverUrl}`;
+}

--- a/src/main/resources/site/controllers/sitemap/sitemap.ts
+++ b/src/main/resources/site/controllers/sitemap/sitemap.ts
@@ -11,31 +11,16 @@ import {toStr} from '@enonic/js-utils/value/toStr';
 import {
 	getSite,
 	getSiteConfig,
-	pageUrl
 } from '/lib/xp/portal';
 // @ts-expect-error No types yet.
 import {render} from '/lib/xslt';
 import {queryForSitemapContent} from '/lib/app-sitemapxml/queryForSitemapContent';
+import {resolveSitemapLoc} from '/lib/app-sitemapxml/resolveSitemapUrl';
 
 
 const DEBUG = false;
 const TRACE = false;
 const VIEW = resolve('sitemap.xsl');
-
-
-function getServerPageUrl(path: string, overrideDomain: string) {
-	return overrideDomain + pageUrl({
-		path,
-		type: 'server'
-	})
-}
-
-function getAbsolutePageUrl(path: string) {
-	return pageUrl({
-		path,
-		type: 'absolute'
-	})
-}
 
 export function get(request: Request<{
 	headers: {
@@ -74,9 +59,7 @@ export function get(request: Request<{
 				changefreq: changefreq[result.hits[i].type],
 				lastmod: result.hits[i].modifiedTime,
 				priority: priority[result.hits[i].type],
-				loc: overrideDomain
-					? getServerPageUrl(result.hits[i]._path, overrideDomain)
-					: getAbsolutePageUrl(result.hits[i]._path)
+				loc: resolveSitemapLoc(result.hits[i], overrideDomain)
 			});
 		}
 	}

--- a/test/guillotine/guillotine.test.ts
+++ b/test/guillotine/guillotine.test.ts
@@ -3,6 +3,7 @@
 
 
 import type {
+	Content,
 	Site,
 } from '@enonic-types/lib-content';
 import type {
@@ -33,6 +34,7 @@ import {print} from 'q-i';
 import {mockLibXpContent} from '../mocks/mockLibXpContent';
 import {mockLibXpContext} from '../mocks/mockLibXpContext';
 import {mockLibXpNode} from '../mocks/mockLibXpNode';
+import {mockLibXpPortal} from '../mocks/mockLibXpPortal';
 
 
 // @ts-ignore TS2339: Property 'log' does not exist on type 'typeof globalThis'.
@@ -129,19 +131,44 @@ const folderContent: BaseFolderContent = {
 	x: {},
 }
 
+const mediaPdfContent = {
+	_id: 'mediaPdfId',
+	_name: 'mediaPdfName',
+	_path: '/sitePath/overvaking/doc',
+	attachments: {
+		'report.pdf': {
+			name: 'report.pdf',
+			size: 100,
+			mimeType: 'application/pdf',
+		},
+	},
+	creator: 'user:system:creator',
+	createdTime: '2021-01-01T00:00:00Z',
+	data: {},
+	displayName: 'mediaPdfDisplayName',
+	owner: 'user:system:owner',
+	type: 'media:document',
+	hasChildren: false,
+	valid: true,
+	x: {},
+}
+
 
 mockLibXpContent({
 	contents: {
 		[siteContent._path]: siteContent,
 		[folderContent._path]: folderContent,
+		[mediaPdfContent._path]: mediaPdfContent as unknown as Content<unknown>,
 	},
 	siteContent
 });
 mockLibXpContext();
+mockLibXpPortal();
 mockLibXpNode({
 	nodes: {
 		[siteContent._path]: siteContent,
 		[folderContent._path]: folderContent,
+		[mediaPdfContent._path]: mediaPdfContent,
 	}
 });
 
@@ -257,6 +284,11 @@ describe('guillotine extensions', () => {
 					changefreq: undefined,
 					lastmod: undefined,
 					path: '/folderContentPath',
+					priority: undefined,
+				},{
+					changefreq: undefined,
+					lastmod: undefined,
+					path: '/_/attachment/sitePath/overvaking/doc/report.pdf',
 					priority: undefined,
 				}
 			]);

--- a/test/mocks/mockLibXpPortal.ts
+++ b/test/mocks/mockLibXpPortal.ts
@@ -1,0 +1,38 @@
+import type {
+	attachmentUrl,
+	pageUrl,
+} from '/lib/xp/portal';
+
+
+import {jest} from '@jest/globals';
+
+
+/**
+ * Minimal portal mocks so resolvers that call {@link pageUrl} / {@link attachmentUrl} run in Jest.
+ */
+export function mockLibXpPortal() {
+	jest.mock(
+		'/lib/xp/portal',
+		() => ({
+			attachmentUrl: jest.fn<typeof attachmentUrl>().mockImplementation((params) => {
+				const path = params.path || '';
+				const name = params.name ? `/${params.name}` : '';
+				const suffix = `${path}${name}`;
+				if (params.type === 'absolute') {
+					return `https://example.invalid/_/attachment${suffix}`;
+				}
+				return `/_/attachment${suffix}`;
+			}),
+			getSite: jest.fn(),
+			getSiteConfig: jest.fn(),
+			pageUrl: jest.fn<typeof pageUrl>().mockImplementation((params) => {
+				const path = params.path || '';
+				if (params.type === 'absolute') {
+					return `https://example.invalid${path}`;
+				}
+				return path;
+			}),
+		}),
+		{virtual: true}
+	);
+}


### PR DESCRIPTION
Emit portal.attachmentUrl for media:* content in sitemap.xml and Guillotine urlset so PDFs and other attachments resolve instead of 404.

Made-with: Cursor