### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = sitemapxml
 appName = com.enonic.app.sitemapxml
 xpVersion=8.0.0-B4
-version=2.0.2-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bumps master `version` from `2.0.2-SNAPSHOT` to `3.0.0-SNAPSHOT`. Master is now the XP 8 line.
- Adds `releaseBranch:` to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so the release tooling recognizes pushes to either as release-branch builds.
- The XP 7 maintenance line continues on the new `2.x` branch (forked from the post-`v2.0.1-B1` SNAPSHOT commit `6f1ecc0`, version `2.0.1-SNAPSHOT`).

## Test plan
- [ ] CI: `Gradle Build` workflow green on this branch
- [ ] After merge: `./gradlew clean build` green on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)