### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `releaseBranch:` to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so pushes to this maintenance branch are recognized as release-branch builds by the release tooling.
- The release-tooling action reads `releaseBranch:` from the workflow file on the branch being built, which is why the same edit needs to land on `2.x` (not just on `master`).
- No version bump on this branch — `2.x` stays at `2.0.1-SNAPSHOT` (XP 7 maintenance line).

## Test plan
- [ ] After merge: a CI run on `2.x` classifies the branch as a release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)