### PR TITLE
Bump @enonic-types/* to ^8.0.0-B4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
         "ms": "^2.1.3"
       },
       "devDependencies": {
-        "@enonic-types/global": "^7.16.3",
+        "@enonic-types/global": "^8.0.0-B4",
         "@enonic-types/guillotine": "^7.3.2",
-        "@enonic-types/lib-content": "^7.16.3",
-        "@enonic-types/lib-context": "^7.16.3",
-        "@enonic-types/lib-node": "^7.16.3",
-        "@enonic-types/lib-portal": "^7.16.3",
+        "@enonic-types/lib-content": "^8.0.0-B4",
+        "@enonic-types/lib-context": "^8.0.0-B4",
+        "@enonic-types/lib-node": "^8.0.0-B4",
+        "@enonic-types/lib-portal": "^8.0.0-B4",
         "@enonic/js-utils": "^1.9.0",
         "@swc/core": "^1.15.33",
         "@types/ms": "^2.1.0",
@@ -598,14 +598,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/@enonic-types/global": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.16.3.tgz",
-      "integrity": "sha512-dEMj48NHDSXVBK4c7eRZAGoh/3xM42Sbf0ZmsnQqxpB69SBfht5m6hXR/weHbnj1mhYPyjWCyB56R3Uhy7NLFg==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-8.0.0-B4.tgz",
+      "integrity": "sha512-CC7OQvPOtxMBfOhnLcDYaMxfdSIaYkbDQ8WnDmXPEPDHMNkraZhirLpdvAnS/7PObS/yEuS94x9GEAqmEd+YFQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
+    },
+    "node_modules/@enonic-types/global/node_modules/@enonic-types/core": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/guillotine": {
       "version": "7.3.2",
@@ -619,45 +624,83 @@
         "@enonic-types/lib-content": "^7.14.0"
       }
     },
-    "node_modules/@enonic-types/lib-content": {
+    "node_modules/@enonic-types/guillotine/node_modules/@enonic-types/global": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.16.3.tgz",
+      "integrity": "sha512-dEMj48NHDSXVBK4c7eRZAGoh/3xM42Sbf0ZmsnQqxpB69SBfht5m6hXR/weHbnj1mhYPyjWCyB56R3Uhy7NLFg==",
+      "dev": true,
+      "dependencies": {
+        "@enonic-types/core": "7.16.3"
+      }
+    },
+    "node_modules/@enonic-types/guillotine/node_modules/@enonic-types/lib-content": {
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@enonic-types/lib-content/-/lib-content-7.16.3.tgz",
       "integrity": "sha512-0Yh5pmuRSJiakGGc+NUfh1cTjTTJfqLZ2s0AuEqMefoQN5zFc1BiBpA4PWxl57GZAxkF1Hn+newCVKL3/Yl6HA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@enonic-types/core": "7.16.3"
       }
+    },
+    "node_modules/@enonic-types/lib-content": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-content/-/lib-content-8.0.0-B4.tgz",
+      "integrity": "sha512-KguGnlIpQRTTIXxeRQtKw0hQLn8cs03Jilfji8k0jFIWnxZ6zkSn3dK/9Ckivle8lq+sXKPRh2F+LlxLOd5sDA==",
+      "dev": true,
+      "dependencies": {
+        "@enonic-types/core": "8.0.0-B4"
+      }
+    },
+    "node_modules/@enonic-types/lib-content/node_modules/@enonic-types/core": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/lib-context": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-context/-/lib-context-7.16.3.tgz",
-      "integrity": "sha512-ne1KMJQf8iMe2vc3EJgttL0GTc60XZfjTDZS3fVez8K0ntCjXHW0Pb1i0tNbfr2QfQ7Nop20HC9NX2fNdkfBhQ==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-context/-/lib-context-8.0.0-B4.tgz",
+      "integrity": "sha512-iFu7mW1w98Hw1HTea5x/b6q/aTPKhUFCfLgwIbQnoE6hgNTEUwx0Vd5qjrSY1tEIKKIioQ9w6VQnyOA/AMwQBw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
+    },
+    "node_modules/@enonic-types/lib-context/node_modules/@enonic-types/core": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/lib-node": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-node/-/lib-node-7.16.3.tgz",
-      "integrity": "sha512-ZrNObSIE4xKwSwcxC9vF3kWsjj47lqHqwhPGW66LW6Zmd020RpgpMVYxO1xBEz8kYUxYMBywzruLea4PevzUOw==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-node/-/lib-node-8.0.0-B4.tgz",
+      "integrity": "sha512-Gw+dc9Qxil0XGQa0i/RX82ztrpmnlBxbCFw+LxsID2E16TifiiD67pkAo/m+KePF7SbxyEVgVvYQw2gEJbUIsw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
+    "node_modules/@enonic-types/lib-node/node_modules/@enonic-types/core": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
+    },
     "node_modules/@enonic-types/lib-portal": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-7.16.3.tgz",
-      "integrity": "sha512-B2bCKGIqDXzGa9tb5uZNNauF6Yf4Ie2qtvqjykzgzJq4B8NKlNr5we7gSZZnB5svBrx0jtqlnMBjtdM92JU7XA==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/lib-portal/-/lib-portal-8.0.0-B4.tgz",
+      "integrity": "sha512-QBs9yjIMyLIurd5KiO6q37lxFEhjlsJo5qmgPk0xk3OeDqbI47rQlJnrqUVR/3z5bvbE2Dx6b+RkRp4r2E7Pbg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
+    },
+    "node_modules/@enonic-types/lib-portal/node_modules/@enonic-types/core": {
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic/js-utils": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "devDependencies": {
-    "@enonic-types/global": "^7.16.3",
+    "@enonic-types/global": "^8.0.0-B4",
     "@enonic-types/guillotine": "^7.3.2",
-    "@enonic-types/lib-content": "^7.16.3",
-    "@enonic-types/lib-context": "^7.16.3",
-    "@enonic-types/lib-node": "^7.16.3",
-    "@enonic-types/lib-portal": "^7.16.3",
+    "@enonic-types/lib-content": "^8.0.0-B4",
+    "@enonic-types/lib-context": "^8.0.0-B4",
+    "@enonic-types/lib-node": "^8.0.0-B4",
+    "@enonic-types/lib-portal": "^8.0.0-B4",
     "@enonic/js-utils": "^1.9.0",
     "@swc/core": "^1.15.33",
     "@types/ms": "^2.1.0",


### PR DESCRIPTION
## Summary
- Bump all `@enonic-types/*` devDependencies (`global`, `lib-content`, `lib-context`, `lib-node`, `lib-portal`) from `^7.16.3` to `^8.0.0-B4` for XP 8 compatibility.
- `@enonic-types/guillotine` left at `^7.3.2` — no 8.x is published on npm yet (latest is 7.3.2).
- Lockfile refreshed via `npm install`.

## Verification
- `npm run check` — passes (TS type check clean).
- `npm run build` (`tsup`) — green.
- `npm test` (jest) — 1/1 tests pass.

No source changes required; the XP 8 type bumps did not surface any new errors.

## Test plan
- [x] `npm run check`
- [x] `npm run build`
- [x] `npm test`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)