### PR TITLE
Bump lib-cache and lib-xslt to 3.0.0-SNAPSHOT #319

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 repositories {
 	mavenLocal()
 	mavenCentral()
-	xp.enonicRepo()
+	xp.enonicRepo('dev')
 }
 
 node {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-cache = "2.2.1"
-xslt  = "2.1.1"
+cache = "3.0.0-SNAPSHOT"
+xslt  = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "cache" }


### PR DESCRIPTION
Closes #319.

## Summary

XP 8 E2E verification of `app-sitemap-xml` at `e45b438` against XP `8.0.0-B4`.

`lib-cache` 2.2.1 and `lib-xslt` 2.1.1 are pre-XP-8 releases. Bumping both to `3.0.0-SNAPSHOT` (sourced from `repo.enonic.com/dev`) is required for clean operation on XP 8. The repository helper is switched from `xp.enonicRepo()` to `xp.enonicRepo('dev')` so Gradle can resolve the SNAPSHOT artifacts.

## E2E result with this patch applied

- `xp-distro` 8.0.0-B4 built clean.
- `./gradlew build --refresh-dependencies` for `app-sitemap-xml` succeeded; the OSGi `include` dependencies pull `lib-cache` and `lib-xslt` 3.0.0-SNAPSHOT classes into `sitemapxml.jar` (verified by unzip listing `com/enonic/lib/cache/*.class` and `com/enonic/lib/xslt/*.class`, plus all 8 `OSGI-INF/com.enonic.lib.xslt.function.*.xml` Declarative-Services descriptors).
- Deployed into a fresh XP install in `/tmp`, server started cleanly.
- Bundle reached ACTIVE: `Started application com.enonic.app.sitemapxml bundle 117`.
- No fatal errors attributable to this app's bundle. The only platform `ERROR` in the log is an unrelated `com.enonic.xp.core.content` `ServiceFactory.getService() resulted in a cycle` boot event seen in every XP 8.0.0-B4 boot.

## Test plan

- [x] `./gradlew build --refresh-dependencies` succeeds.
- [x] App jar contains `com/enonic/lib/cache/*.class` and `com/enonic/lib/xslt/*.class`.
- [x] Bundle reaches ACTIVE on XP 8.0.0-B4.
- [x] No fatal errors attributable to this bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)